### PR TITLE
Switching to "References" tab after SigMakeDialog

### DIFF
--- a/sigmake/Dialog/SigMakeDialog.cpp
+++ b/sigmake/Dialog/SigMakeDialog.cpp
@@ -140,6 +140,7 @@ void MakeSigDialogExecute(HWND hwndDlg)
 	GuiReferenceAddColumn(100, "Disassembly");
 	GuiReferenceSetRowCount((int)results.size());
 	GuiReferenceSetProgress(0);
+	GuiShowReferences();
 
 	int i = 0;
 	for (auto& match : results)

--- a/sigmake/pluginsdk/bridgegraph.h
+++ b/sigmake/pluginsdk/bridgegraph.h
@@ -1,0 +1,186 @@
+#ifndef _GRAPH_H
+#define _GRAPH_H
+
+typedef struct
+{
+    duint addr; //virtual address of the instruction
+    unsigned char data[15]; //instruction bytes
+} BridgeCFInstruction;
+
+typedef struct
+{
+    duint parentGraph; //function of which this node is a part
+    duint start; //start of the block
+    duint end; //end of the block (inclusive)
+    duint brtrue; //destination if condition is true
+    duint brfalse; //destination if condition is false
+    duint icount; //number of instructions in node
+    bool terminal; //node is a RET
+    bool split; //node is a split (brtrue points to the next node)
+    bool indirectcall; //node contains indirect calls (call reg, call [reg+X])
+    void* userdata; //user data
+    ListInfo exits; //exits (including brtrue and brfalse, duint)
+    ListInfo instrs; //block instructions
+} BridgeCFNodeList;
+
+typedef struct
+{
+    duint entryPoint; //graph entry point
+    void* userdata; //user data
+    ListInfo nodes; //graph nodes (BridgeCFNodeList)
+} BridgeCFGraphList;
+
+#ifdef __cplusplus
+#if _MSC_VER >= 1700 && !defined(NO_CPP11)
+
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+#include <utility>
+
+struct BridgeCFNode
+{
+    duint parentGraph = 0; //function of which this node is a part
+    duint start = 0; //va of the first instruction in the block
+    duint end = 0; //va of the last instruction in the block (inclusive)
+    duint brtrue = 0; //destination if condition is true
+    duint brfalse = 0; //destination if condition is false
+    duint icount = 0; //number of instructions in node
+    bool terminal = false; //node is a RET
+    bool split = false; //node is a split (brtrue points to the next node)
+    bool indirectcall = false; //node contains indirect calls (call reg, call [reg+X])
+    void* userdata = nullptr; //user data
+    std::vector<duint> exits; //exits (including brtrue and brfalse)
+    std::vector<BridgeCFInstruction> instrs; //block instructions
+
+    static void Free(const BridgeCFNodeList* nodeList)
+    {
+        if(!BridgeList<duint>::Free(&nodeList->exits))
+            __debugbreak();
+        if(!BridgeList<BridgeCFInstruction>::Free(&nodeList->instrs))
+            __debugbreak();
+    }
+
+    BridgeCFNode() = default;
+
+    BridgeCFNode(const BridgeCFNodeList* nodeList, bool freedata)
+    {
+        if(!nodeList)
+            __debugbreak();
+        parentGraph = nodeList->parentGraph;
+        start = nodeList->start;
+        end = nodeList->end;
+        brtrue = nodeList->brtrue;
+        brfalse = nodeList->brfalse;
+        icount = nodeList->icount;
+        terminal = nodeList->terminal;
+        indirectcall = nodeList->indirectcall;
+        split = nodeList->split;
+        userdata = nodeList->userdata;
+        if(!BridgeList<duint>::ToVector(&nodeList->exits, exits, freedata))
+            __debugbreak();
+        if(!BridgeList<BridgeCFInstruction>::ToVector(&nodeList->instrs, instrs, freedata))
+            __debugbreak();
+    }
+
+    BridgeCFNode(duint parentGraph, duint start, duint end)
+        : parentGraph(parentGraph),
+          start(start),
+          end(end)
+    {
+    }
+
+    BridgeCFNodeList ToNodeList() const
+    {
+        BridgeCFNodeList out;
+        out.parentGraph = parentGraph;
+        out.start = start;
+        out.end = end;
+        out.brtrue = brtrue;
+        out.brfalse = brfalse;
+        out.icount = icount;
+        out.terminal = terminal;
+        out.indirectcall = indirectcall;
+        out.split = split;
+        out.userdata = userdata;
+        BridgeList<duint>::CopyData(&out.exits, exits);
+        BridgeList<BridgeCFInstruction>::CopyData(&out.instrs, instrs);
+        return std::move(out);
+    }
+};
+
+struct BridgeCFGraph
+{
+    duint entryPoint; //graph entry point
+    void* userdata; //user data
+    std::unordered_map<duint, BridgeCFNode> nodes; //CFNode.start -> CFNode
+    std::unordered_map<duint, std::unordered_set<duint>> parents; //CFNode.start -> parents
+
+    static void Free(const BridgeCFGraphList* graphList)
+    {
+        if(!graphList || graphList->nodes.size != graphList->nodes.count * sizeof(BridgeCFNodeList))
+            __debugbreak();
+        auto data = (BridgeCFNodeList*)graphList->nodes.data;
+        for(int i = 0; i < graphList->nodes.count; i++)
+            BridgeCFNode::Free(&data[i]);
+        BridgeFree(data);
+    }
+
+    explicit BridgeCFGraph(const BridgeCFGraphList* graphList, bool freedata)
+    {
+        if(!graphList || graphList->nodes.size != graphList->nodes.count * sizeof(BridgeCFNodeList))
+            __debugbreak();
+        entryPoint = graphList->entryPoint;
+        userdata = graphList->userdata;
+        auto data = (BridgeCFNodeList*)graphList->nodes.data;
+        for(int i = 0; i < graphList->nodes.count; i++)
+            AddNode(BridgeCFNode(&data[i], freedata));
+        if(freedata && data)
+            BridgeFree(data);
+    }
+
+    explicit BridgeCFGraph(duint entryPoint)
+        : entryPoint(entryPoint),
+          userdata(nullptr)
+    {
+    }
+
+    void AddNode(const BridgeCFNode & node)
+    {
+        nodes[node.start] = node;
+        AddParent(node.start, node.brtrue);
+        AddParent(node.start, node.brfalse);
+    }
+
+    void AddParent(duint child, duint parent)
+    {
+        if(!child || !parent)
+            return;
+        auto found = parents.find(child);
+        if(found == parents.end())
+        {
+            parents[child] = std::unordered_set<duint>();
+            parents[child].insert(parent);
+        }
+        else
+            found->second.insert(parent);
+    }
+
+    BridgeCFGraphList ToGraphList() const
+    {
+        BridgeCFGraphList out;
+        out.entryPoint = entryPoint;
+        out.userdata = userdata;
+        std::vector<BridgeCFNodeList> nodeList;
+        nodeList.reserve(nodes.size());
+        for(const auto & nodeIt : nodes)
+            nodeList.push_back(nodeIt.second.ToNodeList());
+        BridgeList<BridgeCFNodeList>::CopyData(&out.nodes, nodeList);
+        return std::move(out);
+    }
+};
+
+#endif //_MSC_VER
+#endif //__cplusplus
+
+#endif //_GRAPH_H

--- a/sigmake/pluginsdk/bridgelist.h
+++ b/sigmake/pluginsdk/bridgelist.h
@@ -1,0 +1,149 @@
+#ifndef _LIST_H
+#define _LIST_H
+
+typedef struct
+{
+    int count; //Number of element in the list.
+    size_t size; //Size of list in bytes (used for type checking).
+    void* data; //Pointer to the list contents. Must be deleted by the caller using BridgeFree (or BridgeList::Free).
+} ListInfo;
+
+#define ListOf(Type) ListInfo*
+
+#ifdef __cplusplus
+
+#include <vector>
+
+/**
+\brief A list object. This object is NOT thread safe.
+\tparam Type BridgeList contents type.
+*/
+template<typename Type>
+class BridgeList
+{
+public:
+    /**
+    \brief BridgeList constructor.
+    \param _freeData (Optional) the free function.
+    */
+    explicit BridgeList()
+    {
+        memset(&_listInfo, 0, sizeof(_listInfo));
+    }
+
+    /**
+    \brief BridgeList destructor.
+    */
+    ~BridgeList()
+    {
+        Cleanup();
+    }
+
+    /**
+    \brief Gets the list data.
+    \return Returns ListInfo->data. Can be null if the list was never initialized. Will be destroyed once this object goes out of scope!
+    */
+    Type* Data() const
+    {
+        return reinterpret_cast<Type*>(_listInfo.data);
+    }
+
+    /**
+    \brief Gets the number of elements in the list. This will crash the program if the data is not consistent with the specified template argument.
+    \return The number of elements in the list.
+    */
+    int Count() const
+    {
+        if(_listInfo.size != _listInfo.count * sizeof(Type)) //make sure the user is using the correct type.
+            __debugbreak();
+        return _listInfo.count;
+    }
+
+    /**
+    \brief Cleans up the list, freeing the list data when it is not null.
+    */
+    void Cleanup()
+    {
+        if(_listInfo.data)
+        {
+            BridgeFree(_listInfo.data);
+            _listInfo.data = nullptr;
+        }
+    }
+
+    /**
+    \brief Reference operator (cleans up the previous list)
+    \return Pointer to the ListInfo.
+    */
+    ListInfo* operator&()
+    {
+        Cleanup();
+        return &_listInfo;
+    }
+
+    /**
+    \brief Array indexer operator. This will crash if you try to access out-of-bounds.
+    \param index Zero-based index of the item you want to get.
+    \return Reference to a value at that index.
+    */
+    Type & operator[](size_t index) const
+    {
+        if(index >= size_t(Count())) //make sure the out-of-bounds access is caught as soon as possible.
+            __debugbreak();
+        return Data()[index];
+    }
+
+    /**
+    \brief Copies data to a ListInfo structure..
+    \param [out] listInfo If non-null, information describing the list.
+    \param listData Data to copy in the ListInfo structure.
+    \return true if it succeeds, false if it fails.
+    */
+    static bool CopyData(ListInfo* listInfo, const std::vector<Type> & listData)
+    {
+        if(!listInfo)
+            return false;
+        listInfo->count = int(listData.size());
+        listInfo->size = listInfo->count * sizeof(Type);
+        if(listInfo->count)
+        {
+            listInfo->data = BridgeAlloc(listInfo->size);
+            Type* curItem = reinterpret_cast<Type*>(listInfo->data);
+            for(const auto & item : listData)
+            {
+                *curItem = item;
+                ++curItem;
+            }
+        }
+        else
+            listInfo->data = nullptr;
+        return true;
+    }
+
+    static bool Free(const ListInfo* listInfo)
+    {
+        if(!listInfo || listInfo->size != listInfo->count * sizeof(Type) || (listInfo->count && !listInfo->data))
+            return false;
+        BridgeFree(listInfo->data);
+        return true;
+    }
+
+    static bool ToVector(const ListInfo* listInfo, std::vector<Type> & listData, bool freedata = true)
+    {
+        if(!listInfo || listInfo->size != listInfo->count * sizeof(Type) || (listInfo->count && !listInfo->data))
+            return false;
+        listData.resize(listInfo->count);
+        for(int i = 0; i < listInfo->count; i++)
+            listData[i] = ((Type*)listInfo->data)[i];
+        if(freedata && listInfo->data)
+            BridgeFree(listInfo->data);
+        return true;
+    }
+
+private:
+    ListInfo _listInfo;
+};
+
+#endif //__cplusplus
+
+#endif //_LIST_H

--- a/sigmake/pluginsdk/bridgemain.h
+++ b/sigmake/pluginsdk/bridgemain.h
@@ -5,6 +5,9 @@
 
 #ifndef __cplusplus
 #include <stdbool.h>
+#define DEFAULT_PARAM(name, value) name
+#else
+#define DEFAULT_PARAM(name, value) name = value
 #endif
 
 //default structure alignments forced
@@ -37,33 +40,128 @@ extern "C"
 
 //Bridge defines
 #define MAX_SETTING_SIZE 65536
-#define DBG_VERSION 21
+#define DBG_VERSION 25
 
 //Bridge functions
-BRIDGE_IMPEXP const char* BridgeInit();
-BRIDGE_IMPEXP const char* BridgeStart();
+
+/// <summary>
+/// Initialize the bridge.
+/// </summary>
+/// <returns>On error it returns a non-null error message.</returns>
+BRIDGE_IMPEXP const wchar_t* BridgeInit();
+
+/// <summary>
+/// Start the bridge.
+/// </summary>
+/// <returns>On error it returns a non-null error message.</returns>
+BRIDGE_IMPEXP const wchar_t* BridgeStart();
+
+/// <summary>
+/// Allocate buffer. Use BridgeFree to free the buffer.
+/// </summary>
+/// <param name="size">Size in bytes of the buffer to allocate.</param>
+/// <returns>A pointer to the allocated buffer. This function will trigger a crash dump if unsuccessful.</returns>
 BRIDGE_IMPEXP void* BridgeAlloc(size_t size);
+
+/// <summary>
+/// Free buffer allocated by BridgeAlloc.
+/// </summary>
+/// <param name="ptr">Buffer to free.</param>
 BRIDGE_IMPEXP void BridgeFree(void* ptr);
+
+/// <summary>
+/// Get a string setting from the in-memory setting store.
+/// </summary>
+/// <param name="section">Section the setting is in. Cannot be null.</param>
+/// <param name="key">Setting key (name). Cannot be null.</param>
+/// <param name="value">Output buffer for the value. Should be of MAX_SETTING_SIZE. Cannot be null.</param>
+/// <returns>True if the setting was found and copied in the value parameter.</returns>
 BRIDGE_IMPEXP bool BridgeSettingGet(const char* section, const char* key, char* value);
+
+/// <summary>
+/// Get an integer setting from the in-memory setting store.
+/// </summary>
+/// <param name="section">Section the setting is in. Cannot be null.</param>
+/// <param name="key">Setting key (name). Cannot be null.</param>
+/// <param name="value">Output value.</param>
+/// <returns>True if the setting was found and successfully converted to an integer.</returns>
 BRIDGE_IMPEXP bool BridgeSettingGetUint(const char* section, const char* key, duint* value);
+
+/// <summary>
+/// Set a string setting in the in-memory setting store.
+/// </summary>
+/// <param name="section">Section the setting is in. Cannot be null.</param>
+/// <param name="key">Setting key (name). Set to null to clear the whole section.</param>
+/// <param name="value">New setting value. Set to null to remove the key from the section.</param>
+/// <returns>True if the operation was successful.</returns>
 BRIDGE_IMPEXP bool BridgeSettingSet(const char* section, const char* key, const char* value);
+
+/// <summary>
+/// Set an integer setting in the in-memory setting store.
+/// </summary>
+/// <param name="section">Section the setting is in. Cannot be null.</param>
+/// <param name="key">Setting key (name). Set to null to clear the whole section.</param>
+/// <param name="value">New setting value.</param>
+/// <returns>True if the operation was successful.</returns>
 BRIDGE_IMPEXP bool BridgeSettingSetUint(const char* section, const char* key, duint value);
+
+/// <summary>
+/// Flush the in-memory setting store to disk.
+/// </summary>
+/// <returns></returns>
+BRIDGE_IMPEXP bool BridgeSettingFlush();
+
+/// <summary>
+/// Read the in-memory setting store from disk.
+/// </summary>
+/// <param name="errorLine">Line where the error occurred. Set to null to ignore this.</param>
+/// <returns>True if the setting were read and parsed correctly.</returns>
+BRIDGE_IMPEXP bool BridgeSettingRead(int* errorLine);
+
+/// <summary>
+/// Get the debugger version.
+/// </summary>
+/// <returns>25</returns>
 BRIDGE_IMPEXP int BridgeGetDbgVersion();
+
+/// <summary>
+/// Checks if the current process is elevated.
+/// </summary>
+/// <returns>true if the process is elevated, false otherwise.</returns>
+BRIDGE_IMPEXP bool BridgeIsProcessElevated();
+
+#ifdef __cplusplus
+}
+#endif
+
+//list structure (and C++ wrapper)
+#include "bridgelist.h"
+
+#include "bridgegraph.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
 
 //Debugger defines
 #define MAX_LABEL_SIZE 256
 #define MAX_COMMENT_SIZE 512
 #define MAX_MODULE_SIZE 256
+#define MAX_IMPORT_SIZE 65536
 #define MAX_BREAKPOINT_SIZE 256
+#define MAX_CONDITIONAL_EXPR_SIZE 256
+#define MAX_CONDITIONAL_TEXT_SIZE 256
 #define MAX_SCRIPT_LINE_SIZE 2048
 #define MAX_THREAD_NAME_SIZE 256
+#define MAX_WATCH_NAME_SIZE 256
 #define MAX_STRING_SIZE 512
 #define MAX_ERROR_SIZE 512
-
-#define TYPE_VALUE 1
-#define TYPE_MEMORY 2
-#define TYPE_ADDR 4
+#define RIGHTS_STRING_SIZE (sizeof("ERWCG") + 1)
+#define MAX_SECTION_SIZE 10
+#define MAX_COMMAND_LINE_SIZE 256
 #define MAX_MNEMONIC_SIZE 64
+#define PAGE_SIZE 0x1000
 
 //Debugger enums
 typedef enum
@@ -87,12 +185,14 @@ typedef enum
 
 typedef enum
 {
-    flagmodule = 1,
-    flaglabel = 2,
-    flagcomment = 4,
-    flagbookmark = 8,
-    flagfunction = 16,
-    flagloop = 32
+    flagmodule = 0x1,
+    flaglabel = 0x2,
+    flagcomment = 0x4,
+    flagbookmark = 0x8,
+    flagfunction = 0x10,
+    flagloop = 0x20,
+    flagargs = 0x40,
+    flagNoFuncOffset = 0x80
 } ADDRINFOFLAGS;
 
 typedef enum
@@ -100,7 +200,9 @@ typedef enum
     bp_none = 0,
     bp_normal = 1,
     bp_hardware = 2,
-    bp_memory = 4
+    bp_memory = 4,
+    bp_dll = 8,
+    bp_exception = 16
 } BPXTYPE;
 
 typedef enum
@@ -118,8 +220,27 @@ typedef enum
     LOOP_BEGIN,
     LOOP_MIDDLE,
     LOOP_ENTRY,
-    LOOP_END
+    LOOP_END,
+    LOOP_SINGLE
 } LOOPTYPE;
+
+//order by most important type last
+typedef enum
+{
+    XREF_NONE,
+    XREF_DATA,
+    XREF_JMP,
+    XREF_CALL
+} XREFTYPE;
+
+typedef enum
+{
+    ARG_NONE,
+    ARG_BEGIN,
+    ARG_MIDDLE,
+    ARG_END,
+    ARG_SINGLE
+} ARGTYPE;
 
 typedef enum
 {
@@ -164,7 +285,40 @@ typedef enum
     DBG_GET_STRING_AT,              // param1=duint addr,                param2=unused
     DBG_GET_FUNCTIONS,              // param1=unused,                    param2=unused
     DBG_WIN_EVENT,                  // param1=MSG* message,              param2=long* result
-    DBG_WIN_EVENT_GLOBAL            // param1=MSG* message,              param2=unused
+    DBG_WIN_EVENT_GLOBAL,           // param1=MSG* message,              param2=unused
+    DBG_INITIALIZE_LOCKS,           // param1=unused,                    param2=unused
+    DBG_DEINITIALIZE_LOCKS,         // param1=unused,                    param2=unused
+    DBG_GET_TIME_WASTED_COUNTER,    // param1=unused,                    param2=unused
+    DBG_SYMBOL_ENUM_FROMCACHE,      // param1=SYMBOLCBINFO* cbInfo,      param2=unused
+    DBG_DELETE_COMMENT_RANGE,       // param1=duint start,               param2=duint end
+    DBG_DELETE_LABEL_RANGE,         // param1=duint start,               param2=duint end
+    DBG_DELETE_BOOKMARK_RANGE,      // param1=duint start,               param2=duint end
+    DBG_GET_XREF_COUNT_AT,          // param1=duint addr,                param2=unused
+    DBG_GET_XREF_TYPE_AT,           // param1=duint addr,                param2=unused
+    DBG_XREF_ADD,                   // param1=duint addr,                param2=duint from
+    DBG_XREF_DEL_ALL,               // param1=duint addr,                param2=unused
+    DBG_XREF_GET,                   // param1=duint addr,                param2=XREF_INFO* info
+    DBG_GET_ENCODE_TYPE_BUFFER,     // param1=duint addr,                param2=unused
+    DBG_ENCODE_TYPE_GET,            // param1=duint addr,                param2=duint size
+    DBG_DELETE_ENCODE_TYPE_RANGE,   // param1=duint start,               param2=duint end
+    DBG_ENCODE_SIZE_GET,            // param1=duint addr,                param2=duint codesize
+    DBG_DELETE_ENCODE_TYPE_SEG,     // param1=duint addr,                param2=unused
+    DBG_RELEASE_ENCODE_TYPE_BUFFER, // param1=void* buffer,              param2=unused
+    DBG_ARGUMENT_GET,               // param1=FUNCTION* info,            param2=unused
+    DBG_ARGUMENT_OVERLAPS,          // param1=FUNCTION* info,            param2=unused
+    DBG_ARGUMENT_ADD,               // param1=FUNCTION* info,            param2=unused
+    DBG_ARGUMENT_DEL,               // param1=FUNCTION* info,            param2=unused
+    DBG_GET_WATCH_LIST,             // param1=ListOf(WATCHINFO),         param2=unused
+    DBG_SELCHANGED,                 // param1=hWindow,                   param2=VA
+    DBG_GET_PROCESS_HANDLE,         // param1=unused,                    param2=unused
+    DBG_GET_THREAD_HANDLE,          // param1=unused,                    param2=unused
+    DBG_GET_PROCESS_ID,             // param1=unused,                    param2=unused
+    DBG_GET_THREAD_ID,              // param1=unused,                    param2=unused
+    DBG_GET_PEB_ADDRESS,            // param1=DWORD ProcessId,           param2=unused
+    DBG_GET_TEB_ADDRESS,            // param1=DWORD ThreadId,            param2=unused
+    DBG_ANALYZE_FUNCTION,           // param1=BridgeCFGraphList* graph,  param2=duint entry
+    DBG_MENU_PREPARE,               // param1=int hMenu,                 param2=unused
+    DBG_GET_SYMBOL_INFO,            // param1=void* symbol,              param2=SYMBOLINFO* info
 } DBGMSG;
 
 typedef enum
@@ -267,15 +421,104 @@ typedef enum
     size_byte = 1,
     size_word = 2,
     size_dword = 4,
-    size_qword = 8
+    size_qword = 8,
+    size_xmmword = 16,
+    size_ymmword = 32
 } MEMORY_SIZE;
+
+typedef enum
+{
+    enc_unknown,  //must be 0
+    enc_byte,     //1 byte
+    enc_word,     //2 bytes
+    enc_dword,    //4 bytes
+    enc_fword,    //6 bytes
+    enc_qword,    //8 bytes
+    enc_tbyte,    //10 bytes
+    enc_oword,    //16 bytes
+    enc_mmword,   //8 bytes
+    enc_xmmword,  //16 bytes
+    enc_ymmword,  //32 bytes
+    enc_zmmword,  //64 bytes avx512 not supported
+    enc_real4,    //4 byte float
+    enc_real8,    //8 byte double
+    enc_real10,   //10 byte decimal
+    enc_ascii,    //ascii sequence
+    enc_unicode,  //unicode sequence
+    enc_code,     //start of code
+    enc_junk,     //junk code
+    enc_middle    //middle of data
+} ENCODETYPE;
+
+typedef enum
+{
+    TYPE_UINT, // unsigned integer
+    TYPE_INT,  // signed integer
+    TYPE_FLOAT,// single precision floating point value
+    TYPE_ASCII, // ascii string
+    TYPE_UNICODE, // unicode string
+    TYPE_INVALID // invalid watch expression or data type
+} WATCHVARTYPE;
+
+typedef enum
+{
+    MODE_DISABLED, // watchdog is disabled
+    MODE_ISTRUE,   // alert if expression is not 0
+    MODE_ISFALSE,  // alert if expression is 0
+    MODE_CHANGED,  // alert if expression is changed
+    MODE_UNCHANGED // alert if expression is not changed
+} WATCHDOGMODE;
+
+typedef enum
+{
+    hw_access,
+    hw_write,
+    hw_execute
+} BPHWTYPE;
+
+typedef enum
+{
+    mem_access,
+    mem_read,
+    mem_write,
+    mem_execute
+} BPMEMTYPE;
+
+typedef enum
+{
+    dll_load = 1,
+    dll_unload,
+    dll_all
+} BPDLLTYPE;
+
+typedef enum
+{
+    ex_firstchance = 1,
+    ex_secondchance,
+    ex_all
+} BPEXTYPE;
+
+typedef enum
+{
+    hw_byte,
+    hw_word,
+    hw_dword,
+    hw_qword
+} BPHWSIZE;
+
+typedef enum
+{
+    sym_import,
+    sym_export,
+    sym_symbol
+} SYMBOLTYPE;
 
 //Debugger typedefs
 typedef MEMORY_SIZE VALUE_SIZE;
-typedef struct SYMBOLINFO_ SYMBOLINFO;
+
 typedef struct DBGFUNCTIONS_ DBGFUNCTIONS;
 
-typedef void (*CBSYMBOLENUM)(SYMBOLINFO* symbol, void* user);
+typedef bool (*CBSYMBOLENUM)(const struct SYMBOLPTR_* symbol, void* user);
 
 //Debugger structs
 typedef struct
@@ -300,6 +543,17 @@ typedef struct
     char name[MAX_BREAKPOINT_SIZE];
     char mod[MAX_MODULE_SIZE];
     unsigned short slot;
+    // extended part
+    unsigned char typeEx; //BPHWTYPE/BPMEMTYPE/BPDLLTYPE/BPEXTYPE
+    unsigned char hwSize; //BPHWSIZE
+    unsigned int hitCount;
+    bool fastResume;
+    bool silent;
+    char breakCondition[MAX_CONDITIONAL_EXPR_SIZE];
+    char logText[MAX_CONDITIONAL_TEXT_SIZE];
+    char logCondition[MAX_CONDITIONAL_EXPR_SIZE];
+    char commandText[MAX_CONDITIONAL_TEXT_SIZE];
+    char commandCondition[MAX_CONDITIONAL_EXPR_SIZE];
 } BRIDGEBP;
 
 typedef struct
@@ -310,8 +564,21 @@ typedef struct
 
 typedef struct
 {
+    char WatchName[MAX_WATCH_NAME_SIZE];
+    char Expression[MAX_CONDITIONAL_EXPR_SIZE];
+    unsigned int window;
+    unsigned int id;
+    WATCHVARTYPE varType;
+    WATCHDOGMODE watchdogMode;
+    duint value;
+    bool watchdogTriggered;
+} WATCHINFO;
+
+typedef struct
+{
     duint start; //OUT
     duint end; //OUT
+    duint instrcount; //OUT
 } FUNCTION;
 
 typedef struct
@@ -319,6 +586,7 @@ typedef struct
     int depth; //IN
     duint start; //OUT
     duint end; //OUT
+    duint instrcount; //OUT
 } LOOP;
 
 typedef struct
@@ -330,14 +598,19 @@ typedef struct
     bool isbookmark;
     FUNCTION function;
     LOOP loop;
-} ADDRINFO;
+    FUNCTION args;
+} BRIDGE_ADDRINFO;
 
-struct SYMBOLINFO_
+typedef struct SYMBOLINFO_
 {
     duint addr;
     char* decoratedSymbol;
     char* undecoratedSymbol;
-};
+    SYMBOLTYPE type;
+    bool freeDecorated;
+    bool freeUndecorated;
+    DWORD ordinal;
+} SYMBOLINFO;
 
 typedef struct
 {
@@ -367,49 +640,170 @@ typedef struct
 
 typedef struct
 {
-    duint cax;
-    duint ccx;
-    duint cdx;
-    duint cbx;
-    duint csp;
-    duint cbp;
-    duint csi;
-    duint cdi;
+    bool FZ;
+    bool PM;
+    bool UM;
+    bool OM;
+    bool ZM;
+    bool IM;
+    bool DM;
+    bool DAZ;
+    bool PE;
+    bool UE;
+    bool OE;
+    bool ZE;
+    bool DE;
+    bool IE;
+
+    unsigned short RC;
+} MXCSRFIELDS;
+
+typedef struct
+{
+    bool B;
+    bool C3;
+    bool C2;
+    bool C1;
+    bool C0;
+    bool ES;
+    bool SF;
+    bool P;
+    bool U;
+    bool O;
+    bool Z;
+    bool D;
+    bool I;
+
+    unsigned short TOP;
+
+} X87STATUSWORDFIELDS;
+
+typedef struct
+{
+    bool IC;
+    bool IEM;
+    bool PM;
+    bool UM;
+    bool OM;
+    bool ZM;
+    bool DM;
+    bool IM;
+
+    unsigned short RC;
+    unsigned short PC;
+
+} X87CONTROLWORDFIELDS;
+
+typedef struct DECLSPEC_ALIGN(16) _XMMREGISTER
+{
+    ULONGLONG Low;
+    LONGLONG High;
+} XMMREGISTER;
+
+typedef struct
+{
+    XMMREGISTER Low; //XMM/SSE part
+    XMMREGISTER High; //AVX part
+} YMMREGISTER;
+
+typedef struct
+{
+    BYTE    data[10];
+    int     st_value;
+    int     tag;
+} X87FPUREGISTER;
+
+typedef struct
+{
+    WORD   ControlWord;
+    WORD   StatusWord;
+    WORD   TagWord;
+    DWORD   ErrorOffset;
+    DWORD   ErrorSelector;
+    DWORD   DataOffset;
+    DWORD   DataSelector;
+    DWORD   Cr0NpxState;
+} X87FPU;
+
+typedef struct
+{
+    ULONG_PTR cax;
+    ULONG_PTR ccx;
+    ULONG_PTR cdx;
+    ULONG_PTR cbx;
+    ULONG_PTR csp;
+    ULONG_PTR cbp;
+    ULONG_PTR csi;
+    ULONG_PTR cdi;
 #ifdef _WIN64
-    duint r8;
-    duint r9;
-    duint r10;
-    duint r11;
-    duint r12;
-    duint r13;
-    duint r14;
-    duint r15;
+    ULONG_PTR r8;
+    ULONG_PTR r9;
+    ULONG_PTR r10;
+    ULONG_PTR r11;
+    ULONG_PTR r12;
+    ULONG_PTR r13;
+    ULONG_PTR r14;
+    ULONG_PTR r15;
 #endif //_WIN64
-    duint cip;
-    unsigned int eflags;
-    FLAGS flags;
+    ULONG_PTR cip;
+    ULONG_PTR eflags;
     unsigned short gs;
     unsigned short fs;
     unsigned short es;
     unsigned short ds;
     unsigned short cs;
     unsigned short ss;
-    duint dr0;
-    duint dr1;
-    duint dr2;
-    duint dr3;
-    duint dr6;
-    duint dr7;
+    ULONG_PTR dr0;
+    ULONG_PTR dr1;
+    ULONG_PTR dr2;
+    ULONG_PTR dr3;
+    ULONG_PTR dr6;
+    ULONG_PTR dr7;
+    BYTE RegisterArea[80];
+    X87FPU x87fpu;
+    DWORD MxCsr;
+#ifdef _WIN64
+    XMMREGISTER XmmRegisters[16];
+    YMMREGISTER YmmRegisters[16];
+#else // x86
+    XMMREGISTER XmmRegisters[8];
+    YMMREGISTER YmmRegisters[8];
+#endif
+} REGISTERCONTEXT;
+
+typedef struct
+{
+    DWORD code;
+    char name[128];
+} LASTERROR;
+
+typedef struct
+{
+    DWORD code;
+    char name[128];
+} LASTSTATUS;
+
+typedef struct
+{
+    REGISTERCONTEXT regcontext;
+    FLAGS flags;
+    X87FPUREGISTER x87FPURegisters[8];
+    unsigned long long mmx[8];
+    MXCSRFIELDS MxCsrFields;
+    X87STATUSWORDFIELDS x87StatusWordFields;
+    X87CONTROLWORDFIELDS x87ControlWordFields;
+    LASTERROR lastError;
+    LASTSTATUS lastStatus;
 } REGDUMP;
 
 typedef struct
 {
-    DISASM_ARGTYPE type;
+    DISASM_ARGTYPE type; //normal/memory
     SEGMENTREG segment;
     char mnemonic[64];
-    duint constant;
-    duint value;
-    duint memvalue;
+    duint constant; //constant in the instruction (imm/disp)
+    duint value; //equal to constant or equal to the register value
+    duint memvalue; //memsize:[value]
 } DISASM_ARG;
 
 typedef struct
@@ -430,8 +824,8 @@ typedef struct
 typedef struct
 {
     int ThreadNumber;
-    HANDLE hThread;
-    DWORD dwThreadId;
+    HANDLE Handle;
+    DWORD ThreadId;
     duint ThreadStartAddress;
     duint ThreadLocalBase;
     char threadName[MAX_THREAD_NAME_SIZE];
@@ -445,6 +839,10 @@ typedef struct
     THREADPRIORITY Priority;
     THREADWAITREASON WaitReason;
     DWORD LastError;
+    FILETIME UserTime;
+    FILETIME KernelTime;
+    FILETIME CreationTime;
+    ULONG64 Cycles; // Windows Vista or greater
 } THREADALLINFO;
 
 typedef struct
@@ -456,23 +854,28 @@ typedef struct
 
 typedef struct
 {
-    ULONG_PTR value; //displacement / addrvalue (rip-relative)
+    duint value; //displacement / addrvalue (rip-relative)
     MEMORY_SIZE size; //byte/word/dword/qword
     char mnemonic[MAX_MNEMONIC_SIZE];
 } MEMORY_INFO;
 
 typedef struct
 {
-    ULONG_PTR value;
+    duint value;
     VALUE_SIZE size;
 } VALUE_INFO;
+
+//definitions for BASIC_INSTRUCTION_INFO.type
+#define TYPE_VALUE 1
+#define TYPE_MEMORY 2
+#define TYPE_ADDR 4
 
 typedef struct
 {
     DWORD type; //value|memory|addr
     VALUE_INFO value; //immediat
     MEMORY_INFO memory;
-    ULONG_PTR addr; //addrvalue (jumps + calls)
+    duint addr; //addrvalue (jumps + calls)
     bool branch; //jumps/calls
     bool call; //instruction is a call
     int size;
@@ -495,14 +898,51 @@ typedef struct
     int depth;
 } FUNCTION_LOOP_INFO;
 
+typedef struct
+{
+    duint addr;
+    XREFTYPE type;
+} XREF_RECORD;
+
+typedef struct
+{
+    duint refcount;
+    XREF_RECORD* references;
+} XREF_INFO;
+
+typedef struct SYMBOLPTR_
+{
+    duint modbase;
+    const void* symbol;
+} SYMBOLPTR;
+
 //Debugger functions
 BRIDGE_IMPEXP const char* DbgInit();
 BRIDGE_IMPEXP void DbgExit();
-BRIDGE_IMPEXP bool DbgMemRead(duint va, unsigned char* dest, duint size);
-BRIDGE_IMPEXP bool DbgMemWrite(duint va, const unsigned char* src, duint size);
+BRIDGE_IMPEXP bool DbgMemRead(duint va, void* dest, duint size);
+BRIDGE_IMPEXP bool DbgMemWrite(duint va, const void* src, duint size);
 BRIDGE_IMPEXP duint DbgMemGetPageSize(duint base);
 BRIDGE_IMPEXP duint DbgMemFindBaseAddr(duint addr, duint* size);
+
+/// <summary>
+/// Asynchronously execute a debugger command by adding it to the command queue.
+/// Note: the command may not have completed before this call returns. Use this
+/// function if you don't care when the command gets executed.
+///
+/// Example: DbgCmdExec("ClearLog")
+/// </summary>
+/// <param name="cmd">The command to execute.</param>
+/// <returns>True if the command was successfully submitted to the command queue. False if the submission failed.</returns>
 BRIDGE_IMPEXP bool DbgCmdExec(const char* cmd);
+
+/// <summary>
+/// Performs synchronous execution of a debugger command. This function call only
+/// returns after the command has completed.
+///
+/// Example: DbgCmdExecDirect("loadlib advapi32.dll")
+/// </summary>
+/// <param name="cmd">The command to execute.</param>
+/// <returns>True if the command executed successfully, False if there was a problem.</returns>
 BRIDGE_IMPEXP bool DbgCmdExecDirect(const char* cmd);
 BRIDGE_IMPEXP bool DbgMemMap(MEMMAP* memmap);
 BRIDGE_IMPEXP bool DbgIsValidExpression(const char* expression);
@@ -510,14 +950,17 @@ BRIDGE_IMPEXP bool DbgIsDebugging();
 BRIDGE_IMPEXP bool DbgIsJumpGoingToExecute(duint addr);
 BRIDGE_IMPEXP bool DbgGetLabelAt(duint addr, SEGMENTREG segment, char* text);
 BRIDGE_IMPEXP bool DbgSetLabelAt(duint addr, const char* text);
+BRIDGE_IMPEXP void DbgClearLabelRange(duint start, duint end);
 BRIDGE_IMPEXP bool DbgGetCommentAt(duint addr, char* text);
 BRIDGE_IMPEXP bool DbgSetCommentAt(duint addr, const char* text);
+BRIDGE_IMPEXP void DbgClearCommentRange(duint start, duint end);
 BRIDGE_IMPEXP bool DbgGetBookmarkAt(duint addr);
 BRIDGE_IMPEXP bool DbgSetBookmarkAt(duint addr, bool isbookmark);
+BRIDGE_IMPEXP void DbgClearBookmarkRange(duint start, duint end);
 BRIDGE_IMPEXP bool DbgGetModuleAt(duint addr, char* text);
 BRIDGE_IMPEXP BPXTYPE DbgGetBpxTypeAt(duint addr);
 BRIDGE_IMPEXP duint DbgValFromString(const char* string);
-BRIDGE_IMPEXP bool DbgGetRegDump(REGDUMP* regdump);
+BRIDGE_IMPEXP bool DbgGetRegDumpEx(REGDUMP* regdump, size_t size);
 BRIDGE_IMPEXP bool DbgValToString(const char* string, duint value);
 BRIDGE_IMPEXP bool DbgMemIsValidReadPtr(duint addr);
 BRIDGE_IMPEXP int DbgGetBpList(BPXTYPE type, BPMAP* list);
@@ -536,6 +979,7 @@ BRIDGE_IMPEXP SCRIPTLINETYPE DbgScriptGetLineType(int line);
 BRIDGE_IMPEXP void DbgScriptSetIp(int line);
 BRIDGE_IMPEXP bool DbgScriptGetBranchInfo(int line, SCRIPTBRANCH* info);
 BRIDGE_IMPEXP void DbgSymbolEnum(duint base, CBSYMBOLENUM cbSymbolEnum, void* user);
+BRIDGE_IMPEXP void DbgSymbolEnumFromCache(duint base, CBSYMBOLENUM cbSymbolEnum, void* user);
 BRIDGE_IMPEXP bool DbgAssembleAt(duint addr, const char* instruction);
 BRIDGE_IMPEXP duint DbgModBaseFromName(const char* name);
 BRIDGE_IMPEXP void DbgDisasmAt(duint addr, DISASM_INSTR* instr);
@@ -548,10 +992,19 @@ BRIDGE_IMPEXP bool DbgFunctionGet(duint addr, duint* start, duint* end);
 BRIDGE_IMPEXP bool DbgFunctionOverlaps(duint start, duint end);
 BRIDGE_IMPEXP bool DbgFunctionAdd(duint start, duint end);
 BRIDGE_IMPEXP bool DbgFunctionDel(duint addr);
+BRIDGE_IMPEXP bool DbgArgumentGet(duint addr, duint* start, duint* end);
+BRIDGE_IMPEXP bool DbgArgumentOverlaps(duint start, duint end);
+BRIDGE_IMPEXP bool DbgArgumentAdd(duint start, duint end);
+BRIDGE_IMPEXP bool DbgArgumentDel(duint addr);
 BRIDGE_IMPEXP bool DbgLoopGet(int depth, duint addr, duint* start, duint* end);
 BRIDGE_IMPEXP bool DbgLoopOverlaps(int depth, duint start, duint end);
 BRIDGE_IMPEXP bool DbgLoopAdd(duint start, duint end);
 BRIDGE_IMPEXP bool DbgLoopDel(int depth, duint addr);
+BRIDGE_IMPEXP bool DbgXrefAdd(duint addr, duint from);
+BRIDGE_IMPEXP bool DbgXrefDelAll(duint addr);
+BRIDGE_IMPEXP bool DbgXrefGet(duint addr, XREF_INFO* info);
+BRIDGE_IMPEXP size_t DbgGetXrefCountAt(duint addr);
+BRIDGE_IMPEXP XREFTYPE DbgGetXrefTypeAt(duint addr);
 BRIDGE_IMPEXP bool DbgIsRunLocked();
 BRIDGE_IMPEXP bool DbgIsBpDisabled(duint addr);
 BRIDGE_IMPEXP bool DbgSetAutoCommentAt(duint addr, const char* text);
@@ -566,13 +1019,51 @@ BRIDGE_IMPEXP bool DbgGetStringAt(duint addr, char* text);
 BRIDGE_IMPEXP const DBGFUNCTIONS* DbgFunctions();
 BRIDGE_IMPEXP bool DbgWinEvent(MSG* message, long* result);
 BRIDGE_IMPEXP bool DbgWinEventGlobal(MSG* message);
+BRIDGE_IMPEXP bool DbgIsRunning();
+BRIDGE_IMPEXP duint DbgGetTimeWastedCounter();
+BRIDGE_IMPEXP ARGTYPE DbgGetArgTypeAt(duint addr);
+BRIDGE_IMPEXP void* DbgGetEncodeTypeBuffer(duint addr, duint* size);
+BRIDGE_IMPEXP void DbgReleaseEncodeTypeBuffer(void* buffer);
+BRIDGE_IMPEXP ENCODETYPE DbgGetEncodeTypeAt(duint addr, duint size);
+BRIDGE_IMPEXP duint DbgGetEncodeSizeAt(duint addr, duint codesize);
+BRIDGE_IMPEXP bool DbgSetEncodeType(duint addr, duint size, ENCODETYPE type);
+BRIDGE_IMPEXP void DbgDelEncodeTypeRange(duint start, duint end);
+BRIDGE_IMPEXP void DbgDelEncodeTypeSegment(duint start);
+BRIDGE_IMPEXP bool DbgGetWatchList(ListOf(WATCHINFO) list);
+BRIDGE_IMPEXP void DbgSelChanged(int hWindow, duint VA);
+BRIDGE_IMPEXP HANDLE DbgGetProcessHandle();
+BRIDGE_IMPEXP HANDLE DbgGetThreadHandle();
+BRIDGE_IMPEXP DWORD DbgGetProcessId();
+BRIDGE_IMPEXP DWORD DbgGetThreadId();
+BRIDGE_IMPEXP duint DbgGetPebAddress(DWORD ProcessId);
+BRIDGE_IMPEXP duint DbgGetTebAddress(DWORD ThreadId);
+BRIDGE_IMPEXP bool DbgAnalyzeFunction(duint entry, BridgeCFGraphList* graph);
+BRIDGE_IMPEXP duint DbgEval(const char* expression, bool* DEFAULT_PARAM(success, nullptr));
+BRIDGE_IMPEXP void DbgGetSymbolInfo(const SYMBOLPTR* symbolptr, SYMBOLINFO* info);
 
 //Gui defines
-#define GUI_PLUGIN_MENU 0
+typedef enum
+{
+    GUI_PLUGIN_MENU,
+    GUI_DISASM_MENU,
+    GUI_DUMP_MENU,
+    GUI_STACK_MENU,
+    GUI_GRAPH_MENU,
+    GUI_MEMMAP_MENU,
+    GUI_SYMMOD_MENU,
+} GUIMENUTYPE;
 
-#define GUI_DISASSEMBLY 0
-#define GUI_DUMP 1
-#define GUI_STACK 2
+BRIDGE_IMPEXP void DbgMenuPrepare(GUIMENUTYPE hMenu);
+
+typedef enum
+{
+    GUI_DISASSEMBLY,
+    GUI_DUMP,
+    GUI_STACK,
+    GUI_GRAPH,
+    GUI_MEMMAP,
+    GUI_SYMMOD,
+} GUISELECTIONTYPE;
 
 #define GUI_MAX_LINE_SIZE 65536
 #define GUI_MAX_DISASSEMBLY_SIZE 2048
@@ -610,7 +1101,8 @@ typedef enum
     GUI_REF_GETCELLCONTENT,         // param1=int row,              param2=int col
     GUI_REF_RELOADDATA,             // param1=unused,               param2=unused
     GUI_REF_SETSINGLESELECTION,     // param1=int index,            param2=bool scroll
-    GUI_REF_SETPROGRESS,            // param1=int progress,            param2=unused
+    GUI_REF_SETPROGRESS,            // param1=int progress,         param2=unused
+    GUI_REF_SETCURRENTTASKPROGRESS, // param1=int progress,         param2=const char* taskTitle
     GUI_REF_SETSEARCHSTARTCOL,      // param1=int col               param2=unused
     GUI_STACK_DUMP_AT,              // param1=duint addr,           param2=duint csp
     GUI_UPDATE_DUMP_VIEW,           // param1=unused,               param2=unused
@@ -622,20 +1114,84 @@ typedef enum
     GUI_MENU_ADD_ENTRY,             // param1=int hMenu,            param2=const char* title
     GUI_MENU_ADD_SEPARATOR,         // param1=int hMenu,            param2=unused
     GUI_MENU_CLEAR,                 // param1=int hMenu,            param2=unused
-    GUI_SELECTION_GET,              // param1=int hWindow,          param2=SELECTIONDATA* selection
-    GUI_SELECTION_SET,              // param1=int hWindow,          param2=const SELECTIONDATA* selection
+    GUI_SELECTION_GET,              // param1=GUISELECTIONTYPE,     param2=SELECTIONDATA* selection
+    GUI_SELECTION_SET,              // param1=GUISELECTIONTYPE,     param2=const SELECTIONDATA* selection
     GUI_GETLINE_WINDOW,             // param1=const char* title,    param2=char* text
     GUI_AUTOCOMPLETE_ADDCMD,        // param1=const char* cmd,      param2=ununsed
     GUI_AUTOCOMPLETE_DELCMD,        // param1=const char* cmd,      param2=ununsed
-    GUI_AUTOCOMPLETE_CLEARALL,      // param1=ununsed,              param2=unused
+    GUI_AUTOCOMPLETE_CLEARALL,      // param1=unused,               param2=unused
     GUI_SCRIPT_ENABLEHIGHLIGHTING,  // param1=bool enable,          param2=unused
     GUI_ADD_MSG_TO_STATUSBAR,       // param1=const char* msg,      param2=unused
     GUI_UPDATE_SIDEBAR,             // param1=unused,               param2=unused
     GUI_REPAINT_TABLE_VIEW,         // param1=unused,               param2=unused
     GUI_UPDATE_PATCHES,             // param1=unused,               param2=unused
     GUI_UPDATE_CALLSTACK,           // param1=unused,               param2=unused
-    GUI_SYMBOL_REFRESH_CURRENT      // param1=unused,               param2=unused
+    GUI_UPDATE_SEHCHAIN,            // param1=unused,               param2=unused
+    GUI_SYMBOL_REFRESH_CURRENT,     // param1=unused,               param2=unused
+    GUI_UPDATE_MEMORY_VIEW,         // param1=unused,               param2=unused
+    GUI_REF_INITIALIZE,             // param1=const char* name,     param2=unused
+    GUI_LOAD_SOURCE_FILE,           // param1=const char* path,     param2=duint addr
+    GUI_MENU_SET_ICON,              // param1=int hMenu,            param2=ICONINFO*
+    GUI_MENU_SET_ENTRY_ICON,        // param1=int hEntry,           param2=ICONINFO*
+    GUI_SHOW_CPU,                   // param1=unused,               param2=unused
+    GUI_ADD_QWIDGET_TAB,            // param1=QWidget*,             param2=unused
+    GUI_SHOW_QWIDGET_TAB,           // param1=QWidget*,             param2=unused
+    GUI_CLOSE_QWIDGET_TAB,          // param1=QWidget*,             param2=unused
+    GUI_EXECUTE_ON_GUI_THREAD,      // param1=GUICALLBACKEX cb,     param2=void* userdata
+    GUI_UPDATE_TIME_WASTED_COUNTER, // param1=unused,               param2=unused
+    GUI_SET_GLOBAL_NOTES,           // param1=const char* text,     param2=unused
+    GUI_GET_GLOBAL_NOTES,           // param1=char** text,          param2=unused
+    GUI_SET_DEBUGGEE_NOTES,         // param1=const char* text,     param2=unused
+    GUI_GET_DEBUGGEE_NOTES,         // param1=char** text,          param2=unused
+    GUI_DUMP_AT_N,                  // param1=int index,            param2=duint va
+    GUI_DISPLAY_WARNING,            // param1=const char *text,     param2=unused
+    GUI_REGISTER_SCRIPT_LANG,       // param1=SCRIPTTYPEINFO* info, param2=unused
+    GUI_UNREGISTER_SCRIPT_LANG,     // param1=int id,               param2=unused
+    GUI_UPDATE_ARGUMENT_VIEW,       // param1=unused,               param2=unused
+    GUI_FOCUS_VIEW,                 // param1=int hWindow,          param2=unused
+    GUI_UPDATE_WATCH_VIEW,          // param1=unused,               param2=unused
+    GUI_LOAD_GRAPH,                 // param1=BridgeCFGraphList*    param2=unused
+    GUI_GRAPH_AT,                   // param1=duint addr            param2=unused
+    GUI_UPDATE_GRAPH_VIEW,          // param1=unused,               param2=unused
+    GUI_SET_LOG_ENABLED,            // param1=bool isEnabled        param2=unused
+    GUI_ADD_FAVOURITE_TOOL,         // param1=const char* name      param2=const char* description
+    GUI_ADD_FAVOURITE_COMMAND,      // param1=const char* command   param2=const char* shortcut
+    GUI_SET_FAVOURITE_TOOL_SHORTCUT,// param1=const char* name      param2=const char* shortcut
+    GUI_FOLD_DISASSEMBLY,           // param1=duint startAddress    param2=duint length
+    GUI_SELECT_IN_MEMORY_MAP,       // param1=duint addr,           param2=unused
+    GUI_GET_ACTIVE_VIEW,            // param1=ACTIVEVIEW*,          param2=unused
+    GUI_MENU_SET_ENTRY_CHECKED,     // param1=int hEntry,           param2=bool checked
+    GUI_ADD_INFO_LINE,              // param1=const char* infoline, param2=unused
+    GUI_PROCESS_EVENTS,             // param1=unused,               param2=unused
+    GUI_TYPE_ADDNODE,               // param1=void* parent,         param2=TYPEDESCRIPTOR* type
+    GUI_TYPE_CLEAR,                 // param1=unused,               param2=unused
+    GUI_UPDATE_TYPE_WIDGET,         // param1=unused,               param2=unused
+    GUI_CLOSE_APPLICATION,          // param1=unused,               param2=unused
+    GUI_MENU_SET_VISIBLE,           // param1=int hMenu,            param2=bool visible
+    GUI_MENU_SET_ENTRY_VISIBLE,     // param1=int hEntry,           param2=bool visible
+    GUI_MENU_SET_NAME,              // param1=int hMenu,            param2=const char* name
+    GUI_MENU_SET_ENTRY_NAME,        // param1=int hEntry,           param2=const char* name
+    GUI_FLUSH_LOG,                  // param1=unused,               param2=unused
+    GUI_MENU_SET_ENTRY_HOTKEY,      // param1=int hEntry,           param2=const char* hack
+    GUI_REF_SEARCH_GETROWCOUNT,     // param1=unused,               param2=unused
+    GUI_REF_SEARCH_GETCELLCONTENT,  // param1=int row,              param2=int col
+    GUI_MENU_REMOVE,                // param1=int hEntryMenu,       param2=unused
+    GUI_REF_ADDCOMMAND,             // param1=const char* title,    param2=const char* command
+    GUI_OPEN_TRACE_FILE,            // param1=const char* file name,param2=unused
+    GUI_UPDATE_TRACE_BROWSER,       // param1=unused,               param2=unused
+    GUI_INVALIDATE_SYMBOL_SOURCE,   // param1=duint base,           param2=unused
+    GUI_GET_CURRENT_GRAPH,          // param1=BridgeCFGraphList*,   param2=unused
+    GUI_SHOW_REF,                   // param1=unused,               param2=unused
 } GUIMSG;
+
+//GUI Typedefs
+struct _TYPEDESCRIPTOR;
+
+typedef void (*GUICALLBACK)();
+typedef void (*GUICALLBACKEX)(void*);
+typedef bool (*GUISCRIPTEXECUTE)(const char* text);
+typedef void (*GUISCRIPTCOMPLETER)(const char* text, char** entries, int* entryCount);
+typedef bool (*TYPETOSTRING)(const struct _TYPEDESCRIPTOR* type, char* dest, size_t* destCount); //don't change destCount for final failure
 
 //GUI structures
 typedef struct
@@ -651,9 +1207,47 @@ typedef struct
     duint end;
 } SELECTIONDATA;
 
+typedef struct
+{
+    const void* data;
+    duint size;
+} ICONDATA;
+
+typedef struct
+{
+    char name[64];
+    int id;
+    GUISCRIPTEXECUTE execute;
+    GUISCRIPTCOMPLETER completeCommand;
+} SCRIPTTYPEINFO;
+
+typedef struct
+{
+    void* titleHwnd;
+    void* classHwnd;
+    char title[MAX_STRING_SIZE];
+    char className[MAX_STRING_SIZE];
+} ACTIVEVIEW;
+
+typedef struct _TYPEDESCRIPTOR
+{
+    bool expanded; //is the type node expanded?
+    bool reverse; //big endian?
+    const char* name; //type name (int b)
+    duint addr; //virtual address
+    duint offset; //offset to addr for the actual location
+    int id; //type id
+    int size; //sizeof(type)
+    TYPETOSTRING callback; //convert to string
+    void* userdata; //user data
+} TYPEDESCRIPTOR;
+
 //GUI functions
+//code page is utf8
+BRIDGE_IMPEXP const char* GuiTranslateText(const char* Source);
 BRIDGE_IMPEXP void GuiDisasmAt(duint addr, duint cip);
 BRIDGE_IMPEXP void GuiSetDebugState(DBGSTATE state);
+BRIDGE_IMPEXP void GuiSetDebugStateFast(DBGSTATE state);
 BRIDGE_IMPEXP void GuiAddLogMessage(const char* msg);
 BRIDGE_IMPEXP void GuiLogClear();
 BRIDGE_IMPEXP void GuiUpdateAllViews();
@@ -680,16 +1274,22 @@ BRIDGE_IMPEXP void GuiSymbolRefreshCurrent();
 BRIDGE_IMPEXP void GuiReferenceAddColumn(int width, const char* title);
 BRIDGE_IMPEXP void GuiReferenceSetRowCount(int count);
 BRIDGE_IMPEXP int GuiReferenceGetRowCount();
+BRIDGE_IMPEXP int GuiReferenceSearchGetRowCount();
 BRIDGE_IMPEXP void GuiReferenceDeleteAllColumns();
+BRIDGE_IMPEXP void GuiReferenceInitialize(const char* name);
 BRIDGE_IMPEXP void GuiReferenceSetCellContent(int row, int col, const char* str);
-BRIDGE_IMPEXP const char* GuiReferenceGetCellContent(int row, int col);
+BRIDGE_IMPEXP char* GuiReferenceGetCellContent(int row, int col);
+BRIDGE_IMPEXP char* GuiReferenceSearchGetCellContent(int row, int col);
 BRIDGE_IMPEXP void GuiReferenceReloadData();
 BRIDGE_IMPEXP void GuiReferenceSetSingleSelection(int index, bool scroll);
 BRIDGE_IMPEXP void GuiReferenceSetProgress(int progress);
+BRIDGE_IMPEXP void GuiReferenceSetCurrentTaskProgress(int progress, const char* taskTitle);
 BRIDGE_IMPEXP void GuiReferenceSetSearchStartCol(int col);
 BRIDGE_IMPEXP void GuiStackDumpAt(duint addr, duint csp);
 BRIDGE_IMPEXP void GuiUpdateDumpView();
+BRIDGE_IMPEXP void GuiUpdateWatchView();
 BRIDGE_IMPEXP void GuiUpdateThreadView();
+BRIDGE_IMPEXP void GuiUpdateMemoryView();
 BRIDGE_IMPEXP void GuiAddRecentFile(const char* file);
 BRIDGE_IMPEXP void GuiSetLastException(unsigned int exception);
 BRIDGE_IMPEXP bool GuiGetDisassembly(duint addr, char* text);
@@ -697,8 +1297,9 @@ BRIDGE_IMPEXP int GuiMenuAdd(int hMenu, const char* title);
 BRIDGE_IMPEXP int GuiMenuAddEntry(int hMenu, const char* title);
 BRIDGE_IMPEXP void GuiMenuAddSeparator(int hMenu);
 BRIDGE_IMPEXP void GuiMenuClear(int hMenu);
-BRIDGE_IMPEXP bool GuiSelectionGet(int hWindow, SELECTIONDATA* selection);
-BRIDGE_IMPEXP bool GuiSelectionSet(int hWindow, const SELECTIONDATA* selection);
+BRIDGE_IMPEXP void GuiMenuRemove(int hEntryMenu);
+BRIDGE_IMPEXP bool GuiSelectionGet(GUISELECTIONTYPE hWindow, SELECTIONDATA* selection);
+BRIDGE_IMPEXP bool GuiSelectionSet(GUISELECTIONTYPE hWindow, const SELECTIONDATA* selection);
 BRIDGE_IMPEXP bool GuiGetLineWindow(const char* title, char* text);
 BRIDGE_IMPEXP void GuiAutoCompleteAddCmd(const char* cmd);
 BRIDGE_IMPEXP void GuiAutoCompleteDelCmd(const char* cmd);
@@ -708,6 +1309,60 @@ BRIDGE_IMPEXP void GuiUpdateSideBar();
 BRIDGE_IMPEXP void GuiRepaintTableView();
 BRIDGE_IMPEXP void GuiUpdatePatches();
 BRIDGE_IMPEXP void GuiUpdateCallStack();
+BRIDGE_IMPEXP void GuiUpdateSEHChain();
+BRIDGE_IMPEXP void GuiLoadSourceFileEx(const char* path, duint addr);
+BRIDGE_IMPEXP void GuiMenuSetIcon(int hMenu, const ICONDATA* icon);
+BRIDGE_IMPEXP void GuiMenuSetEntryIcon(int hEntry, const ICONDATA* icon);
+BRIDGE_IMPEXP void GuiMenuSetEntryChecked(int hEntry, bool checked);
+BRIDGE_IMPEXP void GuiMenuSetVisible(int hMenu, bool visible);
+BRIDGE_IMPEXP void GuiMenuSetEntryVisible(int hEntry, bool visible);
+BRIDGE_IMPEXP void GuiMenuSetName(int hMenu, const char* name);
+BRIDGE_IMPEXP void GuiMenuSetEntryName(int hEntry, const char* name);
+BRIDGE_IMPEXP void GuiMenuSetEntryHotkey(int hEntry, const char* hack);
+BRIDGE_IMPEXP void GuiShowCpu();
+BRIDGE_IMPEXP void GuiAddQWidgetTab(void* qWidget);
+BRIDGE_IMPEXP void GuiShowQWidgetTab(void* qWidget);
+BRIDGE_IMPEXP void GuiCloseQWidgetTab(void* qWidget);
+BRIDGE_IMPEXP void GuiExecuteOnGuiThread(GUICALLBACK cbGuiThread);
+BRIDGE_IMPEXP void GuiUpdateTimeWastedCounter();
+BRIDGE_IMPEXP void GuiSetGlobalNotes(const char* text);
+BRIDGE_IMPEXP void GuiGetGlobalNotes(char** text);
+BRIDGE_IMPEXP void GuiSetDebuggeeNotes(const char* text);
+BRIDGE_IMPEXP void GuiGetDebuggeeNotes(char** text);
+BRIDGE_IMPEXP void GuiDumpAtN(duint va, int index);
+BRIDGE_IMPEXP void GuiDisplayWarning(const char* title, const char* text);
+BRIDGE_IMPEXP void GuiRegisterScriptLanguage(SCRIPTTYPEINFO* info);
+BRIDGE_IMPEXP void GuiUnregisterScriptLanguage(int id);
+BRIDGE_IMPEXP void GuiUpdateArgumentWidget();
+BRIDGE_IMPEXP void GuiFocusView(int hWindow);
+BRIDGE_IMPEXP bool GuiIsUpdateDisabled();
+BRIDGE_IMPEXP void GuiUpdateEnable(bool updateNow);
+BRIDGE_IMPEXP void GuiUpdateDisable();
+BRIDGE_IMPEXP bool GuiLoadGraph(BridgeCFGraphList* graph, duint addr);
+BRIDGE_IMPEXP duint GuiGraphAt(duint addr);
+BRIDGE_IMPEXP void GuiUpdateGraphView();
+BRIDGE_IMPEXP void GuiDisableLog();
+BRIDGE_IMPEXP void GuiEnableLog();
+BRIDGE_IMPEXP void GuiAddFavouriteTool(const char* name, const char* description);
+BRIDGE_IMPEXP void GuiAddFavouriteCommand(const char* name, const char* shortcut);
+BRIDGE_IMPEXP void GuiSetFavouriteToolShortcut(const char* name, const char* shortcut);
+BRIDGE_IMPEXP void GuiFoldDisassembly(duint startAddress, duint length);
+BRIDGE_IMPEXP void GuiSelectInMemoryMap(duint addr);
+BRIDGE_IMPEXP void GuiGetActiveView(ACTIVEVIEW* activeView);
+BRIDGE_IMPEXP void GuiAddInfoLine(const char* infoLine);
+BRIDGE_IMPEXP void GuiProcessEvents();
+BRIDGE_IMPEXP void* GuiTypeAddNode(void* parent, const TYPEDESCRIPTOR* type);
+BRIDGE_IMPEXP bool GuiTypeClear();
+BRIDGE_IMPEXP void GuiUpdateTypeWidget();
+BRIDGE_IMPEXP void GuiCloseApplication();
+BRIDGE_IMPEXP void GuiFlushLog();
+BRIDGE_IMPEXP void GuiReferenceAddCommand(const char* title, const char* command);
+BRIDGE_IMPEXP void GuiUpdateTraceBrowser();
+BRIDGE_IMPEXP void GuiOpenTraceFile(const char* fileName);
+BRIDGE_IMPEXP void GuiInvalidateSymbolSource(duint base);
+BRIDGE_IMPEXP void GuiExecuteOnGuiThreadEx(GUICALLBACKEX cbGuiThread, void* userdata);
+BRIDGE_IMPEXP void GuiGetCurrentGraph(BridgeCFGraphList* graphList);
+BRIDGE_IMPEXP void GuiShowReferences();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
At the moment the plugin doesn't do anything with GUI when you click "Scan" button in the `SigMakeDialog`. Recently new function was added to the x64dbg called `GuiShowReferences` that switch GUI focus to the "References" tab. I think it fits perfect there, as it is bit confusing especially for new plugin users when nothing is happening after clicking "Scan".

I've also updated the necessary SDK headers. Keep in mind that I did nothing with the `.a` files, as the linker asked me for .lib during compilation, totally ignoring the .a files that are in the repository.